### PR TITLE
improve regex to account for deeper relative paths

### DIFF
--- a/helpers/dependency-tree-builder.js
+++ b/helpers/dependency-tree-builder.js
@@ -4,7 +4,7 @@ module.exports = function(theme, file) {
 
   function findDependencies(file, dependencyTree) {
     var content = fs.readFileSync(file, 'utf8'),
-        path    = file.replace(/(\/[^/]+\..*)/g, ''),
+        path    = file.replace(/(.*)\/.*/g, '$1'),
         regex   = /(?:\n@import )(?:'|")(.*)(?:'|")/g;
         result  = '',
         imports = [];


### PR DESCRIPTION
allow greedy regex to match up to final "/" of path and discard the remaining chars (the file name)
current regex fails when path begins with "../../"