### PR TITLE
Create relative symlink instead of full path symlink

### DIFF
--- a/tasks/symlink.js
+++ b/tasks/symlink.js
@@ -1,13 +1,14 @@
 module.exports = function() {
-  // global vars
-  var gulp    = this.gulp,
-      plugins = this.opts.plugins,
-      config  = this.opts.configs;
+  // Global variables
+  var plugins = this.opts.plugins,
+    config  = this.opts.configs;
 
-  // local plugins
+  // Create a relative symlink from <project root>/tools to the root of this package
   const fs = require('fs');
+  const path = require('path');
 
-  fs.symlink(fs.realpathSync('./'), config.projectPath + '/tools', 'dir', () => {
+  const relativeDirectory = path.relative(config.projectPath, fs.realpathSync('./'));
+  fs.symlink(relativeDirectory, config.projectPath + '/tools', 'dir', () => {
     plugins.util.log(
       plugins.util.colors.green('Symlink created. Now you can use Frontools from "tools" directory at root of your project.')
     );

--- a/tasks/symlink.js
+++ b/tasks/symlink.js
@@ -1,11 +1,11 @@
 module.exports = function() {
   // Global variables
   var plugins = this.opts.plugins,
-    config  = this.opts.configs;
+      config  = this.opts.configs;
 
   // Create a relative symlink from <project root>/tools to the root of this package
-  const fs = require('fs');
-  const path = require('path');
+  const fs = require('fs'),
+        path = require('path');
 
   const relativeDirectory = path.relative(config.projectPath, fs.realpathSync('./'));
   fs.symlink(relativeDirectory, config.projectPath + '/tools', 'dir', () => {


### PR DESCRIPTION
I noticed fs.realpathSync('./') is used to create a full path symlink. Since you might want to commit the symlink into git I changed this to a relative symlink.