### PR TITLE
WIP: Refactor compilation to merge source files, then compile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,6 +41,11 @@ Object.keys(config.themes).forEach(name => {
       'flatten:' + name + ':' + locale,
       require('./helper/flatten').bind(null, gulp, plugins, config, name, locale)
     );
+
+    gulp.task(
+      ['copy', name, locale].join(':'),
+      require('./helper/static')(gulp, plugins, config, name, locale)
+    );
   });
 
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,5 +36,11 @@ Object.keys(config.themes).forEach(name => {
       theme.lang + ':' + name + ':' + locale,
       require('./helper/' + theme.lang)(gulp, plugins, config, name, locale)
     );
+
+    gulp.task(
+      'flatten:' + name + ':' + locale,
+      require('./helper/flatten').bind(null, gulp, plugins, config, name, locale)
+    );
   });
+
 });

--- a/helper/flatten.js
+++ b/helper/flatten.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const getModules = require('./modules');
+
+function getThemePaths(themeName, themes) {
+  const theme = themes[themeName];
+  if (theme.parent) {
+    return [theme.src].concat(getThemePaths(theme.parent, themes));
+  }
+
+  return [theme.src];
+}
+
+module.exports = function flattenThemeHierarchy(gulp, plugins, config, name, locale) {
+  const themes = config.themes;
+  const themePaths = getThemePaths(name, themes);
+
+  const webPathMaps = [];
+  webPathMaps.push([path.join(config.projectPath, 'lib/web'), '/']);
+
+  const themeWebPaths = themePaths.map(function appendWebPath (themePath) {
+    return path.join(
+      config.projectPath,
+      themePath,
+      'web'
+    );
+  });
+
+  themeWebPaths.forEach(function addThemeToPathMap (themePath) {
+    webPathMaps.push([themePath, '/']);
+  });
+
+  const themeI18nWebPaths = themePaths.map(function appendI18NPath (themePath) {
+    return path.join(
+      config.projectPath,
+      themePath,
+      'web/i18n',
+      locale
+    );
+  });
+
+  themeI18nWebPaths.forEach(function addThemeToPathMap (themePath) {
+    webPathMaps.push([themePath, '/']);
+  });
+
+  const modules = getModules(config.projectPath);
+
+  Object.keys(modules).forEach(function addModuleToPathMap (moduleName) {
+    webPathMaps.push([path.join(modules[moduleName], 'view/base/web'), moduleName]);
+    webPathMaps.push([path.join(modules[moduleName], 'view', themes[name].area, 'web'), moduleName]);
+    webPathMaps.push([path.join(modules[moduleName], 'view/base/web/i18n', locale), moduleName]);
+    webPathMaps.push([path.join(modules[moduleName], 'view', themes[name].area, 'web/i18n', locale), moduleName]);
+
+    themePaths.forEach(function addModuleThemeOverrides (themePath) {
+      webPathMaps.push([path.join(
+        config.projectPath,
+        themePath,
+        moduleName,
+        'web'
+      ), moduleName]);
+
+      webPathMaps.push([path.join(
+        config.projectPath,
+        themePath,
+        moduleName,
+        'web/i18n',
+        locale
+      ), moduleName]);
+    });
+  });
+
+  const staticFiles = {};
+
+  webPathMaps.forEach(function globForStaticFiles (map) {
+    const source = map[0];
+    const destination = map[1];
+
+    const results = plugins.globby.sync(
+      '**/*',
+      {
+        cwd: source,
+        nodir: true,
+      }
+    );
+
+    results.forEach(function (result) {
+      staticFiles[path.join(destination, result)] = path.join(source, result);
+    });
+  });
+
+  Object.keys(staticFiles).forEach(function makeSymlinkForStaticFile(staticFile) {
+    const source = staticFiles[staticFile];
+    const location = path.join(
+      config.projectPath,
+      'var/frontools',
+      name,
+      locale,
+      staticFile
+    );
+
+    plugins.mkdirp.sync(path.dirname(location));
+    fs.symlinkSync(source, location);
+  });
+
+  // do stuff
+  // Find all files in /lib/web/
+  // Iterate through all themes' web/
+  // Iterate through all themes' web/i18n/{locale}/
+  // Iterate through all modules' view/base/web/
+  // Iterate through all modules' view/{area}/web/
+  // Iterate through all themes' Module_Name/web/
+  // Iterate through all modules' view/base/web/i18n/{locale}/
+  // Iterate through all modules' view/{area}/web/i18n/{locale}/
+  // Iterate through all themes' Module_Name/web/i18n/{locale}
+  //
+  // Maintain the above as map of file location to accessible URL under pub/static/...
+  //
+  // Then loop through and write out and create all directories, then create all file symlinks.
+  //
+  // Then this task is done, and I need to change scss task to work on that directory.
+  // Then write JS task.
+};

--- a/helper/modules.js
+++ b/helper/modules.js
@@ -1,0 +1,10 @@
+const spawnSync = require('child_process').spawnSync
+
+module.exports = function getEnabledMagentoModules(projectPath) {
+  const process = spawnSync(
+    'php',
+    [projectPath + '/vendor/snowdog/frontools/php/get_modules.php']
+  );
+
+  return JSON.parse(process.stdout.toString());
+};

--- a/helper/static.js
+++ b/helper/static.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const path = require('path');
+
+module.exports = function staticTask(gulp, plugins, config, name, locale) {
+  return function copyFiles() {
+    const theme = config.themes[name];
+    const filetypes = [
+      'css',
+      'csv',
+      'eot',
+      'gif',
+      'htc',
+      'htm',
+      'html',
+      'ico',
+      'jbf',
+      'jpg',
+      'js',
+      'json',
+      'less',
+      'map',
+      'md',
+      'png',
+      'scss',
+      'svg',
+      'swf',
+      'ttf',
+      'txt',
+      'woff',
+      'woff2',
+    ];
+
+    const src = filetypes.map(function getGlob (ext) {
+      return '**/*.' + ext
+    });
+
+    const dest = path.join(
+      config.projectPath,
+      theme.dest,
+      locale
+    );
+
+    return gulp
+      .src(
+        src,
+        { cwd: path.join(config.projectPath, 'var/frontools', name, locale) }
+      )
+      .pipe(plugins.plumber({
+        errorHandler: plugins.notify.onError('Error: <%= error.message %>')
+      }))
+      .pipe(gulp.dest(dest));
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "devDependencies": {
     "autoprefixer": "~6.3.7",
-    "browser-sync": "~2.14.0",
+    "browser-sync": "~2.13.0",
     "cssnano": "~3.7.3",
     "fs-extra": "~0.30.0",
     "globby": "~6.0.0",
@@ -36,6 +36,7 @@
     "js-yaml": "~3.6.1",
     "marked": "~0.3.5",
     "marked-terminal": "~1.6.1",
+    "mkdirp": "^0.5.1",
     "postcss-reporter": "~1.4.1",
     "run-sequence": "~1.2.2",
     "stylelint": "~7.0.3"

--- a/php/get_modules.php
+++ b/php/get_modules.php
@@ -1,0 +1,19 @@
+<?php
+
+require(__DIR__ . '/../../../../app/bootstrap.php');
+
+$params = $_SERVER;
+$params[\Magento\Store\Model\StoreManager::PARAM_RUN_CODE] = 'admin';
+$params[\Magento\Store\Model\Store::CUSTOM_ENTRY_POINT_PARAM] = true;
+$params['entryPoint'] = basename(__FILE__);
+
+$objectManagerFactory = Magento\Framework\App\Bootstrap::createObjectManagerFactory(BP, $params);
+$objectManager = $objectManagerFactory->create($params);
+
+$componentRegistrar = $objectManager->create(
+    'Magento\Framework\Component\ComponentRegistrar'
+);
+
+$modules = $componentRegistrar->getPaths('module');
+
+echo json_encode($modules, JSON_PRETTY_PRINT);


### PR DESCRIPTION
This work started with me asking a question in #69. I thought a proof of concept might be a bit more illustrative than writing more words. It's not done yet, by any means.

Conceptually, one thing is different from before: I have separated the "resolving the theme hierarchy" step, and the "compile our assets step". It turns out that most front end toolchains are not familiar with Magento's theme fallback, which is a lot more dynamic in Magento 2. I go through the entire theme hierarchy, and generate a "pre-compile" version of `pub/static` in a directory `var/frontools`.  There are then gulp tasks that work on that area, and put things into `pub/static`. While this isn't strictly necessary for stylesheet compilation, I believe there are several advantages:

+ It iterates over all module static assets, and handles i18n in the theme fallback, in a way that (I believe) is compatible with how Magento builds its assets.
+ It compiles all static assets, not just stylesheets, and leaves a space where they can be optimised. Right now, I just have a catchall task that copies files.
+ There are several edge cases in how Sass themes are compiled now. If you make a child theme of the `sass-blank-theme`, you have to make `scss/styles.scss`, even if you change nothing about it, because it needs to find that entry point, or it won't compile anything.

## How Does the Compilation Work?

In a step I call flattening, I take every place where static assets can appear, and, in order of precedence, collect all the static assets they expose, keyed by the URL they would have in `pub/static`. This is a one-many map. I take the last file I find for each URL, since that is the one that is "on top" in a theme hierararchy sense.

To find all module static assets, I get an up to date list of the installed modules from Magento, and where they are in the filesystem. I have a dependency-less PHP file added to this project to get this information.

I then export symlinks of all of those files to the holding area `var/frontools/{themename}/{locale}`. The symlinks have a few interesting properties:

+ File changes show up there automatically (of course)
+ Gulp will pick up those changes if it is watching a symlink.

This means that you can watch just that directory, and pick up changes to files, even from modules that export their own JavaScript. The key use cases for this are developing modules with JavaScript, and having a full suite of tools, and also developing a website where you have a parent theme and a child theme (which happens quite regularly for me).

The second step is that the things actually get compiled. Right now I have two tasks, but there could be more, for development, production, and different file types.

## Watchers

**I have not implemented any watchers yet**

There are several options for what to watch. For files that are already existing, changes to them will be picked up by watching `var/frontend/{themename}/{locale}`.

It's what happens when you add or remove files that gets tricky. It's not practical to watch every theme, and every module, because the performance implications would be too large. That's also overkill. No developer is ever simultaneously working on everything, including the core.

I think it is enough just to watch the active theme directory for additions and deletions, and do a partial rebuild of `/var/frontools/{themename}/{locale}`. That will be fast, and then it will trigger a change in the other watcher.

For changes in a parent theme, or elsewhere, I think it is acceptable to force the developer to rebuild in that case. It doesn't take too long, and I think those cases will be relatively rare.

## Performance

+ The Sass task has been heavily doctored, but the meat of it is the same. It runs in the same timeframe of between 1 and 3 seconds.
+ The Copying task takes a similar time of around 3 seconds
+ The full Flatten task takes around 5 seconds to run on my computer, but 3 seconds of that is taken up by me asking Magento which modules are installed.

## Known Issues

There are several issues with this, since it's super early. I just wanted to show it first, and get feedback on how it is seen and whether it is worthwhile.

+ There are no watchers
+ There are no cleanup tasks, so `pub/static` and `var/frontools` have to be manually emptied
+ There is no treatment for JavaScript yet, which is one of the things I want most.
+ There are some stylesheets in the `sass-blank-theme` called `Magento_BraintreeTwo`. Since I can't find this module anywhere, it doesn't get found and imported into `var/frontools`, so the Sass compilation breaks. I had to remove the `@import` line in `styles.scss`.
+ The `styles` directories containing all the Sass had to be moved inside the `web` directories for their modules, and in the theme. This was achieved by the following commands:

  ```
  find . -name 'Magento_*' -type d -exec mkdir -p {}/web \;
  find . -name 'Magento_*' -type d -exec cp -r {}/styles {}/web/ \;
  ```

Please let me know what you think. I believe that resolving the theme hierarchy first affords a great deal more power to the front-end toolchain, and lets Magento 2 take part in something a bit more modern, building on the great work that you have already done.

If you read this much, then thanks, too 👏 