### PR TITLE
Simplified inheritance fallback

### DIFF
--- a/helper/parent-theme-dir.js
+++ b/helper/parent-theme-dir.js
@@ -1,20 +1,18 @@
 'use strict';
-module.exports = function(themeName, config, plugins) { // eslint-disable-line func-names
-  function getParentThemeDir(themeName) {
-    let theme = config.themes[themeName];
+module.exports = function (themeName, config) { // eslint-disable-line func-names
+  const paths = [];
 
-    if (theme.parent) {
-      let src   = config.themes[theme.parent].src,
-          paths = plugins.globby.sync(
-            config.projectPath + src + '/**/',
-            { ignore: '/**/node_modules/**' }
-          );
+  function getThemePath(themeName) {
+    const theme = config.themes[themeName];
 
-      return paths.concat(getParentThemeDir(theme.parent));
-    }
-    else {
-      return [];
+    paths.push(config.projectPath + theme.src);
+
+    if(theme.parent) {
+      getThemePath(theme.parent);
     }
   }
-  return getParentThemeDir(themeName);
+
+  getThemePath(themeName);
+
+  return paths;
 };

--- a/helper/parent-theme-dir.js
+++ b/helper/parent-theme-dir.js
@@ -1,5 +1,5 @@
 'use strict';
-module.exports = function (themeName, config) { // eslint-disable-line func-names
+module.exports = function(themeName, config) { // eslint-disable-line func-names
   const paths = [];
 
   function getThemePath(themeName) {
@@ -7,7 +7,7 @@ module.exports = function (themeName, config) { // eslint-disable-line func-name
 
     paths.push(config.projectPath + theme.src);
 
-    if(theme.parent) {
+    if (theme.parent) {
       getThemePath(theme.parent);
     }
   }


### PR DESCRIPTION
Right now the inheritance array in frontools looks like this:
```
[ 'PROJECT/vendor/snowdog/theme-blank-sass/',
  'PROJECT/vendor/snowdog/theme-blank-sass/etc/',
  'PROJECT/vendor/snowdog/theme-blank-sass/i18n/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_AdvancedCheckout/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_AdvancedCheckout/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_AdvancedSearch/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_AdvancedSearch/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Banner/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Banner/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Braintree/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Braintree/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_BraintreeTwo/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_BraintreeTwo/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Bundle/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Bundle/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Catalog/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Catalog/layout/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Catalog/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Catalog/styles/module/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_CatalogEvent/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_CatalogEvent/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_CatalogSearch/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_CatalogSearch/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Checkout/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Checkout/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Checkout/styles/module/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Checkout/styles/module/checkout/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Cms/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Cms/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Customer/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Customer/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Downloadable/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Downloadable/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftCard/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftCard/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftCardAccount/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftCardAccount/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftMessage/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftMessage/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftRegistry/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftRegistry/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftWrapping/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GiftWrapping/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GroupedProduct/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_GroupedProduct/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Invitation/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Invitation/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_LayeredNavigation/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_LayeredNavigation/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Msrp/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Msrp/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_MultipleWishlist/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_MultipleWishlist/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Multishipping/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Multishipping/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Newsletter/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Newsletter/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Paypal/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Paypal/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Paypal/styles/module/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_ProductVideo/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_ProductVideo/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Review/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Review/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Reward/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Reward/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Rma/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Rma/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Sales/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Sales/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_SalesRule/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_SalesRule/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_SendFriend/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_SendFriend/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Swatches/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Swatches/layout/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Swatches/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Swatches/web/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Swatches/web/images/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Theme/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Theme/layout/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Theme/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Vault/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Vault/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_VersionsCms/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_VersionsCms/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Weee/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Weee/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Wishlist/',
  'PROJECT/vendor/snowdog/theme-blank-sass/Magento_Wishlist/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/styles/',
  'PROJECT/vendor/snowdog/theme-blank-sass/styles/blocks/',
  'PROJECT/vendor/snowdog/theme-blank-sass/styles/blocks/components/',
  'PROJECT/vendor/snowdog/theme-blank-sass/styles/mixins/',
  'PROJECT/vendor/snowdog/theme-blank-sass/styles/vendor/',
  'PROJECT/vendor/snowdog/theme-blank-sass/styles/vendor/magento-ui/',
  'PROJECT/vendor/snowdog/theme-blank-sass/styles/vendor/magento-ui/variables/',
  'PROJECT/vendor/snowdog/theme-blank-sass/styles/vendor/normalize/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/fonts/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/fonts/Blank-Theme-Icons/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/fonts/opensans/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/fonts/opensans/bold/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/fonts/opensans/light/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/fonts/opensans/regular/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/fonts/opensans/semibold/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/images/',
  'PROJECT/vendor/snowdog/theme-blank-sass/web/js/' ]
```

IMHO this should be the following when you have a parent theme in `themes.json`:
```
[
  'PROJECT/app/design/frontend/NAMESPACE/THEMENAME',
  'PROJECT/vendor/snowdog/theme-blank-sass'
]
```

So lets say we're using theme-blank-sass as our parent theme, here's an example:
[this](https://github.com/SnowdogApps/magento2-theme-blank-sass/blob/master/styles/styles.scss#L39) line shown below:

```
@import '../Magento_AdvancedCheckout/styles/module';
```

would become:
```
@import 'Magento_AdvancedCheckout/styles/module';
```

If you would want to override `Magento_AdvancedCheckout/styles/_module.scss` you would just have to place the file in your child theme and it will get picked up by frontools automagically because of the include paths.

@Igloczek is this something you can agree to?
