### PR TITLE
Change the inheritance resolver to use multiple parent themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you want to keep config files inside frontools `config` dir, you have to hand
 First of all check `config/themes.json.sample`
 - `src` - full path to theme
 - `dest` - full path to `pub/static/[theme_area]/[theme_vendor]/[theme_name]`
-- `parent` - name of parent theme
+- `parent` - array name of parent theme(s).
 - `locale` - array of available locales
 - `localeOverwrites` - set to `true` only if your theme have per locale customizations
 - `lang` - define styles lang want to use for processing, should be same as files extension. Out of the box Frontools supports only `scss`

--- a/config/themes.json.sample
+++ b/config/themes.json.sample
@@ -9,7 +9,7 @@
   "custom": {
     "src"             : "vendor/snowdog/theme-custom",
     "dest"            : "pub/static/frontend/Snowdog/custom",
-    "parent"          : "blank",
+    "parent"          : ["blank"],
     "locale"          : ["en_US", "pl_PL"],
     "localeOverwrites": true,
     "lang"            : "scss",

--- a/helper/inheritance-resolver.js
+++ b/helper/inheritance-resolver.js
@@ -19,18 +19,20 @@ module.exports = function(plugins, config, name) { // eslint-disable-line func-n
 
   // Create symlinks for themes without any per locale modifcations
   if (!theme.localeOverwrites) {
-    // If theme have parent, create symlinks to all avaliabe files and then overwite only neccessary
+    // If theme have (multiple) parent(s), create symlinks to all avaliabe files and then overwite only neccessary
     if (theme.parent) {
-      const parentSrc = config.projectPath + config.themes[theme.parent].src;
-      plugins.globby.sync([
-        parentSrc + '/**/*.' + theme.lang,
-        '!/**/node_modules/**'
-      ]).forEach(srcPath => {
-        createSymlink(
-          srcPath,
-          themeDest + srcPath.replace(parentSrc, '').replace('/web', '')
-        );
-      });
+      theme.parent.forEach(parent => {
+	    const parentSrc = config.projectPath + config.themes[parent].src;
+	    plugins.globby.sync([
+	      parentSrc + '/**/*.' + theme.lang,
+	      '!/**/node_modules/**'
+	    ]).forEach(srcPath => {
+	      createSymlink(
+	        srcPath,
+	        themeDest + srcPath.replace(parentSrc, '').replace('/web', '')
+	      );
+	    });
+	  });
     }
 
     // Create symlinks to all files in this theme. Will overwritte parent symlinks if exist.
@@ -48,19 +50,20 @@ module.exports = function(plugins, config, name) { // eslint-disable-line func-n
   else {
     // We have to handle every locale independly, b/c of possible overwrites
     theme.locale.forEach(locale => {
-      // If theme have parent, create symlinks to all avaliabe files and then overwitte only neccessary
+      // If theme have (multiple) parent(s), create symlinks to all avaliabe files and then overwitte only neccessary
       if (theme.parent) {
-        const parentSrc = config.projectPath + config.themes[theme.parent].src;
-        plugins.globby.sync([
-          parentSrc + '/**/*.' + theme.lang,
-          '!/**/i18n/**',
-          '!/**/node_modules/**'
-        ]).forEach(srcPath => {
-          createSymlink(
-            srcPath,
-            themeDest + '/' + locale + srcPath.replace(parentSrc, '').replace('/web', '')
-          );
-        });
+        theme.parent.forEach(parent => {
+	      const parentSrc = config.projectPath + config.themes[parent].src;
+	      plugins.globby.sync([
+	        parentSrc + '/**/*.' + theme.lang,
+	        '!/**/node_modules/**'
+	      ]).forEach(srcPath => {
+	        createSymlink(
+	          srcPath,
+	          themeDest + srcPath.replace(parentSrc, '').replace('/web', '')
+	        );
+	      });
+	    });
       }
 
       // Create symlinks to all files in this theme. Will overwritte parent symlinks if exist.


### PR DESCRIPTION
**Problem**
We we're trying to use theme-blank-sass as a parent of our base-theme but when we tried to make a child theme out of our base-theme the inheritance was only for one parent.

**Solution**
Changed the inheritance resolver to make use of an foreach to check if there were multiple parent themes in an array set in themes.json.

**How to use**
Instead of using a string for the parent element use an array.
For the first child only call the first parent
For the second child call the first child an the parent etc.

**Example**
```
{
  "parent": {
    "src"    : "vendor/VendorName/parent",
    "dest"   : "pub/static/frontend/VendorName/parent",
    "locale" : ["en_US", "nl_NL"],
    "lang"   : "scss",
    "postcss": ["plugins.autoprefixer()"]
  },
  "first-child": {
    "src"    : "vendor/VendorName/first-child",
    "dest"   : "pub/static/frontend/VendorName/first-child",
    "locale" : ["en_US", "nl_NL"],
    "parent" : ["parent"],
    "lang"   : "scss",
    "postcss": ["plugins.autoprefixer()"]
  },
  "second-child": {
    "src"    : "vendor/VendorName/second-child",
    "dest"   : "pub/static/frontend/VendorName/second-child",
    "locale" : ["en_US", "nl_NL"],
    "parent" : ["parent", "first-child"],
    "lang"   : "scss",
    "postcss": ["plugins.autoprefixer()"]
  },
  "third-child": {
    "src"    : "vendor/VendorName/third-child",
    "dest"   : "pub/static/frontend/VendorName/third-child",
    "locale" : ["en_US", "nl_NL"],
    "parent" : ["parent", "first-child", "second-child"],
    "lang"   : "scss",
    "postcss": ["plugins.autoprefixer()"]
  }
}
```
