### PR TITLE
Add ES6 module syntax

### DIFF
--- a/helper/babel.js
+++ b/helper/babel.js
@@ -6,7 +6,7 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
         disableMaps = plugins.util.env.disableMaps || false,
         production  = plugins.util.env.prod || false,
         babelConfig = {
-          presets: require('babel-preset-env')
+          presets: require('babel-preset-env'),
           plugins: [
             'babel-plugin-add-return-default-exports',
             'babel-plugin-transform-es2015-modules-amd'

--- a/helper/babel.js
+++ b/helper/babel.js
@@ -7,6 +7,10 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
         production  = plugins.util.env.prod || false,
         babelConfig = {
           presets: require('babel-preset-env')
+          plugins: [
+            'babel-plugin-add-return-default-exports',
+            'babel-plugin-transform-es2015-modules-amd'
+          ].map(require.resolve)
         };
 
   function adjustDestinationDirectory(file) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "autoprefixer": "~6.7.7",
+    "babel-plugin-add-return-default-exports": "^0.1.0",
     "babel-preset-env": "~1.2.1",
     "browser-sync": "~2.18.8",
     "cssnano": "~3.10.0",


### PR DESCRIPTION
# ES6 Modules!

I don't particularly like requireJs code, I think i've found a simple solution to prevent having to write it.
**Under the hood this still uses requireJs**. This is just a nicer way to write it.

### What this gives us!

*Before*:

```
define(['jquery'], function($) {

    var Topmenu = {
        initialize: function() {
            //... Do some stuff with $
        }
    }

    return function(config, element) {
        Topmenu.initalize(config, element);
    }
});
```

*After*:

```
import $ from 'jquery';

let Topmenu = {
    initialize: () => {
        //... do some stuff with $
    }
};

export default (config, element) => {
    Topmenu.initalize(config, element);
}
```

We can also write our own modules

*js/example*
```
const example = () => {

}

export {default}
```

Then we can easily import
```
import {example} from './example'

example();
```

## How this works

**Under the hood this still uses requireJs**. This is just a nicer way to write it.

In the babel helper task I added the plugin 'babel-plugin-transform-es2015-modules-amd' which tells babel to transpile to amd syntax. (This plugin was already there, just not being used)

Magento requires us to return a function from a requireJs module for it to be initialised in a template.
I added 'babel-plugin-add-return-default-exports' to allow us export a default and this just works. (I had to add this plugin to the package.json)
```
export default (config, element) => {
    //do some stuff
}
```

This transpiles to

```
exports.default = function (config, element) {
    //some stuff
};

return exports['default'];
```

I had to use `.map(require.resolve)` to get the plugins to load correctly.

`gulp babel` will handle all this, no extra steps required!

If support for `.babelrc` comes in the future, this could be placed in there.

What do you think of this?