### PR TITLE
Inheritance is broken when child name is : parentname+'suffix'

### DIFF
--- a/helper/inheritance-resolver.js
+++ b/helper/inheritance-resolver.js
@@ -39,7 +39,7 @@ module.exports = function(plugins, config, name) { // eslint-disable-line func-n
         });
       }
       else {
-        destPath = destPath.replace(replacePattern, '');
+        destPath = destPath.replace(replacePattern+'/', '/');
       }
       createSymlink(srcPath, destPath);
     });


### PR DESCRIPTION
If parent theme config is: 
```
"src": "app/design/frontend/Sample/Sample",
"dest": "pub/static/frontend/Sample/Sample",
```
And child theme:
```
"src": "app/design/frontend/Sample/Samplechild",
"dest": "pub/static/frontend/Sample/Samplechild",
```
generated path will be : `child/var/www/sample/pub/static/frontend/Sample/Samplechild`