### PR TITLE
Feature/disable prod minification

### DIFF
--- a/config/themes.json.sample
+++ b/config/themes.json.sample
@@ -26,6 +26,7 @@
     "parent": "blank",
     "stylesDir": "web/css",
     "postcss": ["plugins.autoprefixer()"],
+    "disableSuffix": true,
     "modules": {
       "Snowdog_Sample": "vendor/snowdog/module-sample"
     },

--- a/helper/scss.js
+++ b/helper/scss.js
@@ -1,11 +1,12 @@
 'use strict';
 module.exports = function(gulp, plugins, config, name, file) { // eslint-disable-line func-names
-  const theme       = config.themes[name],
-        srcBase     = config.projectPath + 'var/view_preprocessed/frontools' + theme.dest.replace('pub/static', ''),
-        stylesDir   = theme.stylesDir ? theme.stylesDir : 'styles',
-        disableMaps = plugins.util.env.disableMaps || false,
-        production  = plugins.util.env.prod || false,
-        postcss     = [];
+  const theme         = config.themes[name],
+        srcBase       = config.projectPath + 'var/view_preprocessed/frontools' + theme.dest.replace('pub/static', ''),
+        stylesDir     = theme.stylesDir ? theme.stylesDir : 'styles',
+        disableMaps   = plugins.util.env.disableMaps || false,
+        production    = plugins.util.env.prod || false,
+        postcss       = [],
+        disableSuffix = theme.disableSuffix || false;
 
   if (theme.postcss) {
     theme.postcss.forEach(el => {
@@ -52,7 +53,7 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
       .pipe(plugins.if(production, plugins.postcss([plugins.cssnano()])))
       .pipe(plugins.if(postcss.length, plugins.postcss(postcss || [])))
       .pipe(plugins.if(!disableMaps && !production, plugins.sourcemaps.write()))
-      .pipe(plugins.if(production, plugins.rename({ suffix: '.min' })))
+      .pipe(plugins.if(production && !disableSuffix, plugins.rename({ suffix: '.min' })))
       .pipe(plugins.rename(adjustDestinationDirectory))
       .pipe(plugins.multiDest(dest))
       .pipe(plugins.logger({
@@ -86,7 +87,7 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
           .pipe(plugins.if(production, plugins.postcss([plugins.cssnano()])))
           .pipe(plugins.if(postcss.length, plugins.postcss(postcss || [])))
           .pipe(plugins.if(!disableMaps && !production, plugins.sourcemaps.write()))
-          .pipe(plugins.if(production, plugins.rename({ suffix: '.min' })))
+          .pipe(plugins.if(production && !disableSuffix, plugins.rename({ suffix: '.min' })))
           .pipe(plugins.rename(adjustDestinationDirectory))
           .pipe(gulp.dest(config.projectPath + theme.dest + '/' + locale))
           .pipe(plugins.logger({


### PR DESCRIPTION
Production mode `--prod` adds a _.min_ suffix which breaks frontend CSS if you do not have the **Minify CSS Files** admin configuration setting turned on. For various reasons, we may not want to turn it on but still be able to run `gulp styles` in production mode. This PR adds a theme config option to disable adding a filename suffix (.min) on a per theme basis.

Simply add

```json
"disableSuffix": "true",
```

to the themes.json file and .min won't be appended in production mode.


Maybe there is a better approach but this is what I came up with for now.

![screen shot 2017-05-11 at 4 49 24 pm](https://cloud.githubusercontent.com/assets/3484527/25971323/d1951848-3669-11e7-8c5b-b0925055ab3a.png)
