### PR TITLE
Allow passing local postcss modules 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,21 @@ Up from version 1.0.0 we are supporting both Node.js packages managers. If you w
 You can store them in Frontools `config` directory or in `dev/tools/frontools/config`.
 There is a `gulp setup` task to copy all sample config files from the `config` to `dev/tools/frontools/config` and create a convenient symlink `tools` in the project root.
 If you want to keep config files inside frontools `config` dir, you have to handle this manually.
-5. Define your themes in `themes.json`.
+5. Define your themes in `themes.js`.
 
-## `themes.json` structure
-Check `config/themes.json.sample` to get samples.
+## `themes.js` structure
+Check `config/themes.js.sample` to get samples.
 - `src` - full path to theme
 - `dest` - full path to `pub/static/[theme_area]/[theme_vendor]/[theme_name]`
 - `locale` - array of available locales
 - `localeOverwrites` - (default `false`) set to `true` if you want to overwrite some styles for specifilc language. Remember that path to overwriting file has to be same as base file after removing `/i18n/{lang_code}`.
 - `parent` - name of parent theme
 - `stylesDir` - (default `styles`) path to styles directory. For `theme-blank-sass` it's `styles`. By default Magento 2 use `web/css`.
-- `postcss` - (deafult `["plugins.autoprefixer()"]`) PostCSS plugins config. Have to be an array.
+- `postcss` - (default `plugins => [plugins.autoprefixer()]`) PostCSS plugins config.
+    A callback that receives the `plugins` object as a parameter and returns an
+    array of plugins.
+    You can also inject plugins from a local package.json, e.g.:
+    `plugins => [plugins.autoprefixer(), require('postcss-inline-svg')]`
 - `modules` - list of modules witch you want to map inside your theme
 - `ignore` - array of ignore patterns
 

--- a/config/themes.js.sample
+++ b/config/themes.js.sample
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "blank": {
     "src": "vendor/snowdog/theme-blank-sass",
     "dest": "pub/static/frontend/Snowdog/blank",
@@ -25,7 +25,7 @@
     "localeOverwrites": true,
     "parent": "blank",
     "stylesDir": "web/css",
-    "postcss": ["plugins.autoprefixer()"],
+    "postcss": plugins => plugins.autoprefixer(),
     "modules": {
       "Snowdog_Sample": "vendor/snowdog/module-sample"
     },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ const plugins = require('gulp-load-plugins')({
 
 config.projectPath = plugins.fs.realpathSync('../../../') + '/';
 config.tempPath = config.projectPath + 'var/view_preprocessed/frontools';
-config.themes = require('./helper/config-loader')('themes.json', plugins, config, false);
+config.themes = require('./helper/config-loader')('themes.js', plugins, config, false);
 
 plugins.errorMessage = require('./helper/error-message')(plugins);
 plugins.getThemes = require('./helper/get-themes')(plugins, config);

--- a/helper/config-loader.js
+++ b/helper/config-loader.js
@@ -12,7 +12,7 @@ module.exports = function(file, plugins, config, failOnError) { // eslint-disabl
       return plugins.yaml.safeLoad(plugins.fs.readFileSync(externalPath));
     }
     else {
-      return JSON.parse(plugins.fs.readFileSync(externalPath));
+      return require(externalPath);
     }
   }
   else if (plugins.globby.sync('config/' + file).length) {

--- a/helper/get-themes.js
+++ b/helper/get-themes.js
@@ -8,14 +8,14 @@ module.exports = function(plugins, config) { // eslint-disable-line func-names
     if (themes.length === 0) {
       throw new plugins.util.PluginError({
         'plugin' : 'config',
-        'message': plugins.errorMessage('You have to create themes.json')
+        'message': plugins.errorMessage('You have to create themes.js')
       })
     }
 
     if (themeName && themes.indexOf(themeName) === -1) {
       throw new plugins.util.PluginError({
         plugin : 'config',
-        message: plugins.errorMessage(themeName + ' theme is not defined in themes.json')
+        message: plugins.errorMessage(themeName + ' theme is not defined in themes.js')
       });
     }
 

--- a/helper/scss.js
+++ b/helper/scss.js
@@ -4,13 +4,11 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
         srcBase     = config.projectPath + 'var/view_preprocessed/frontools' + theme.dest.replace('pub/static', ''),
         stylesDir   = theme.stylesDir ? theme.stylesDir : 'styles',
         disableMaps = plugins.util.env.disableMaps || false,
-        production  = plugins.util.env.prod || false,
-        postcss     = [];
+        production  = plugins.util.env.prod || false;
+  let postcss = [];
 
   if (theme.postcss) {
-    theme.postcss.forEach(el => {
-      postcss.push(eval(el));
-    });
+    postcss = theme.postcss(plugins);
   }
   else {
     postcss.push(plugins.autoprefixer());


### PR DESCRIPTION
Refactor themes.json as themes.js to allow using postcss plugins that don't ship with frontools and avoid using`eval`.

This would be a breaking change. It would be better to include fallback handling for themes.json but I didn't have time.