### PR TITLE
Include version number in package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "magento2-frontools",
+  "version": "1.5.0",
   "author": {
     "name": "Bartek Igielski",
     "email": "igloczek@gmail.com"


### PR DESCRIPTION
Currently, `npm` fails when trying to install from another `package.json` file. An example of this is when I use npm scripts to install it. `package.json` is **required** to have two parameters: `name` and `version` ([see docs](https://docs.npmjs.com/getting-started/using-a-package.json)). While this could add an extra step for updates in the future, it would be nice to be able to install this package remotely.