### PR TITLE
Allow deploying to web folder

### DIFF
--- a/helper/scss.js
+++ b/helper/scss.js
@@ -33,6 +33,10 @@ module.exports = function(gulp, plugins, config, name, file) { // eslint-disable
     dest.push(config.projectPath + theme.dest + '/' + locale);
   });
 
+  if(theme.deployToWeb) {
+    dest.push(config.projectPath + theme.dest.replace('pub/static', 'app/design') + '/' + 'web');
+  }
+
   return gulp.src(
     file || srcBase + '/**/*.scss',
     { base: srcBase }


### PR DESCRIPTION
Allow configuring themes.json with deployToWeb flag in order to allow compiling to the web folder along with pub/static folders.
Use case: 
- develop on development server, use direct compilation to pub static for fast development
- once development is done the compiled source will be available in web/css also, allowing for easy deployment to staging/production environments where the theme is versioned and deployed by setup:static-content:deploy.