### PR TITLE
Add svg inline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Please use `yarn [taskName]` or `npm run [taskName]` to avoid necessity of insta
   * `--ci` - Enable throwing errors. Useful in CI/CD pipelines.
 * `svg` - Run [svg-sprite](https://github.com/jkphl/gulp-svg-sprite) to generate SVG sprite.
   * `--theme name` - Process single theme.
+* `svginline` - Create Svg inline [gulp-sass-inline-svg](https://www.npmjs.com/package/gulp-sass-inline-svg)
+  * Put svg icon in /web/icons/svg/
 * `watch` - Watch for style changes and run processing tasks.
   * `--theme name` - Process single theme.
   * `--disableLinting` - Disable SASS and CSS linting.

--- a/gulpfile.esm.js
+++ b/gulpfile.esm.js
@@ -13,6 +13,7 @@ import { sasslint as sassLintTask } from './tasks/sass-lint'
 import { setup as setupTask } from './tasks/setup'
 import { styles as stylesTask } from './tasks/styles'
 import { svg as svgTask } from './tasks/svg'
+import { svginline as svgInlineTask } from './tasks/svginline'
 import { watch as watchTask } from './tasks/watch'
 import magepackBundleTask from './tasks/magepack-bundle'
 import magepackGenerateTask from './tasks/magepack-generate'
@@ -28,6 +29,7 @@ export const sasslint = sassLintTask
 export const setup = setupTask
 export const styles = series(inheritanceTask, stylesTask)
 export const svg = series(inheritanceTask, svgTask)
+export const svginline = series(inheritanceTask, svgInlineTask)
 export const watch = watchTask
 export const magepackBundle = magepackBundleTask
 export const magepackGenerate = magepackGenerateTask

--- a/helpers/svginline.js
+++ b/helpers/svginline.js
@@ -1,0 +1,21 @@
+import { src } from 'gulp'
+import logger from 'gulp-logger'
+import sassInlineSvg from 'm2-sass-inlinesvg'
+
+import { projectPath, themes } from './config'
+
+export default name => {
+  const theme = themes[name]
+  const stylesDir = theme.stylesDir ? theme.stylesDir : 'styles'
+
+  return src(projectPath + theme['src'] + '/**/icons/**/*.svg')
+    .pipe(sassInlineSvg({
+      destDir: projectPath + theme['src'] + '/' + stylesDir + '/svg',
+      prefix: 'default'
+    }))
+    .pipe(logger({
+      display: 'name',
+      beforeEach: 'Theme: ' + name + ' ',
+      afterEach: ' Compiled!'
+    }))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "magento2-frontools",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1968,6 +1968,120 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "cheerio": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+      "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
+      "requires": {
+        "css-select": "~1.0.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "~3.8.1",
+        "lodash": "^3.2.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+          "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "1.0",
+            "domutils": "1.4",
+            "nth-check": "~1.0.0"
+          }
+        },
+        "css-what": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+          "integrity": "sha1-18wt9FGAZm+Z0rFEYmOUaeAPc2w="
+        },
+        "dom-serializer": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+          "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "entities": "^1.1.1"
+          }
+        },
+        "domhandler": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "domutils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+          "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+          "requires": {
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        },
+        "htmlparser2": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+          "requires": {
+            "domelementtype": "1",
+            "domhandler": "2.3",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
+          },
+          "dependencies": {
+            "domutils": {
+              "version": "1.5.1",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+              "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+              "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
+            }
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "chokidar": {
       "version": "3.4.3",
@@ -6721,6 +6835,48 @@
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "requires": {
         "es5-ext": "~0.10.2"
+      }
+    },
+    "m2-sass-inlinesvg": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/m2-sass-inlinesvg/-/m2-sass-inlinesvg-1.0.4.tgz",
+      "integrity": "sha512-0U9cu5Cm6xO8x2PbP0nR83ImyLnCqr7Bfgs7Wj245QM9HUc5Y+nwsFKauWJPy4+BNn09R5wh779uHc73xtXHvA==",
+      "requires": {
+        "cheerio": "^0.19.0",
+        "gulp-util": "^3.0.4",
+        "through2": "^0.6.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        }
       }
     },
     "magepack": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-svg-sprite": "^1.5.0",
     "gulp-uglify": "^3.0.2",
     "js-yaml": "^3.14.0",
+    "m2-sass-inlinesvg": "^1.0.4",
     "magepack": "^2.4.0",
     "marked": "^1.2.2",
     "marked-terminal": "^4.1.0",
@@ -73,6 +74,7 @@
     "setup": "gulp setup",
     "styles": "gulp styles",
     "svg": "gulp svg",
+    "svginline": "gulp svginline",
     "watch": "gulp watch",
     "test": "eslint *.js helpers/*.js tasks/*.js"
   },

--- a/tasks/svginline.js
+++ b/tasks/svginline.js
@@ -1,0 +1,11 @@
+import mergeStream from 'merge-stream'
+import helper from '../helpers/svginline'
+import themes from '../helpers/get-themes'
+
+export const svginline = () => {
+  const streams = mergeStream()
+  themes().forEach(name => {
+    streams.add(helper(name))
+  })
+  return streams
+}


### PR DESCRIPTION
Base on https://www.npmjs.com/package/m2-sass-inlinesvg

After using gulp svginline
All files under `/web/icons/*.svg` are compile into one file in `/styles/_default_sass-inline-svg-data.scss`
Another file is create `/styles/_default_sass-inline-svg.scss` who need to be import in your styles.scss  (`@import "svg/default_sass-inline-svg";`)

